### PR TITLE
Debug console

### DIFF
--- a/core/src/com/jalfsoftware/jalf/Jalf.java
+++ b/core/src/com/jalfsoftware/jalf/Jalf.java
@@ -2,8 +2,16 @@ package com.jalfsoftware.jalf;
 
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.Screen;
+import com.jalfsoftware.jalf.screens.AbstractScreen;
 import com.jalfsoftware.jalf.screens.MenuScreen;
+import com.jalfsoftware.jalf.services.ConsoleManager;
 import com.jalfsoftware.jalf.services.PreferencesManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 
 /**
  * Einstiegsklasse für das Spiel
@@ -13,9 +21,51 @@ public class Jalf extends Game {
 
     // Services
     private PreferencesManager preferencesManager;
+    private ConsoleManager     consoleManager;
 
     public PreferencesManager getPreferencesManager() {
         return preferencesManager;
+    }
+
+    public ConsoleManager getConsoleManager() {
+        return consoleManager;
+    }
+
+    private void initializeConsoleCommands() {
+        consoleManager.clearCommands();
+
+        consoleManager.addCommand(new ConsoleManager.ConsoleCommand("test", new ConsoleManager.CommandExecutor() {
+            @Override
+            public void OnCommandFired(HashMap<String, String> parValuePairs) {
+                if (parValuePairs.containsKey("x")) {
+                    Gdx.app.log(LOG, parValuePairs.get("x"));
+                }
+                if (parValuePairs.containsKey("y")) {
+                    Gdx.app.log(LOG, parValuePairs.get("y"));
+                }
+            }
+        }));
+
+        consoleManager.addCommand(new ConsoleManager.ConsoleCommand("fullscreen", new ConsoleManager.CommandExecutor() {
+            @Override
+            public void OnCommandFired(HashMap<String, String> parValuePairs) {
+                if (parValuePairs.containsKey("true")) {
+                    Gdx.graphics
+                            .setDisplayMode(Gdx.graphics.getDesktopDisplayMode().width, Gdx.graphics.getDesktopDisplayMode().height, true);
+                    Gdx.app.log(LOG, "Enabled fullscreen");
+                } else if (parValuePairs.containsKey("false")) {
+                    Gdx.graphics.setDisplayMode((int) AbstractScreen.SCREEN_WIDTH, (int) AbstractScreen.SCREEN_HEIGHT, false);
+                    Gdx.app.log(LOG, "Disabled fullscreen");
+                }
+            }
+        }));
+
+        consoleManager.addCommand(new ConsoleManager.ConsoleCommand("exit", new ConsoleManager.CommandExecutor() {
+            @Override
+            public void OnCommandFired(HashMap<String, String> parValuePairs) {
+                Gdx.app.exit();
+            }
+        }));
     }
 
     @Override
@@ -23,6 +73,8 @@ public class Jalf extends Game {
         Gdx.app.log(LOG, "Creating game on " + Gdx.app.getType());
 
         preferencesManager = new PreferencesManager();
+        consoleManager = new ConsoleManager();
+        initializeConsoleCommands();
     }
 
     @Override
@@ -54,5 +106,13 @@ public class Jalf extends Game {
         Gdx.app.log(LOG, "Resizing game to: " + width + " x " + height);
 
         if (getScreen() == null) setScreen(new MenuScreen(this)); // Bewirkt erste Screenauswahl
+    }
+
+    @Override
+    public void setScreen(Screen screen) {
+        super.setScreen(screen);
+        initializeConsoleCommands();
+        if (screen instanceof ConsoleManager.CommandableScreen)
+            ((ConsoleManager.CommandableScreen) screen).addScreenConsoleCommand(consoleManager);
     }
 }

--- a/core/src/com/jalfsoftware/jalf/entities/Player.java
+++ b/core/src/com/jalfsoftware/jalf/entities/Player.java
@@ -58,7 +58,7 @@ public class Player extends AbstractLivingEntity implements InputProcessor {
         }
     }
 
-    private void respawn() {
+    public void respawn() {
         resetSpeed();
         fireballAvalible = false;
         setPosition(spawnPosition.x, spawnPosition.y);

--- a/core/src/com/jalfsoftware/jalf/screens/AbstractScreen.java
+++ b/core/src/com/jalfsoftware/jalf/screens/AbstractScreen.java
@@ -22,8 +22,8 @@ import com.jalfsoftware.jalf.Jalf;
 public abstract class AbstractScreen implements Screen {
     public static final String LOG = AbstractScreen.class.getSimpleName();
 
-    protected static final float SCREEN_WIDTH  = 800;
-    protected static final float SCREEN_HEIGHT = 480;
+    public static final float SCREEN_WIDTH  = 800;
+    public static final float SCREEN_HEIGHT = 480;
 
     protected final Stage              uiStage; // Stage zum Hosten von UI-Elementen
     protected final Skin               skin; // Skin mit visueller Darstellung des UI
@@ -68,6 +68,7 @@ public abstract class AbstractScreen implements Screen {
     private void setDebugConsoleVisibility(boolean visible) {
         debugConsole.setVisible(visible);
         if(visible) {
+            debugConsole.setText("");
             tempProcessorList = new Array<>();
             tempProcessorList.addAll(inputMultiplexer.getProcessors());
             inputMultiplexer.clear();
@@ -106,7 +107,7 @@ public abstract class AbstractScreen implements Screen {
                     setDebugConsoleVisibility(false);
                     event.cancel();
                 } else if(keycode == Input.Keys.ENTER) {
-                    //TODO: jalf.getConsoleManager().submit(debugConsole.getText());
+                    jalf.getConsoleManager().submitConsoleString(debugConsole.getText());
                 }
                 return super.keyDown(event, keycode);
             }

--- a/core/src/com/jalfsoftware/jalf/screens/GameScreen.java
+++ b/core/src/com/jalfsoftware/jalf/screens/GameScreen.java
@@ -8,14 +8,16 @@ import com.jalfsoftware.jalf.Jalf;
 import com.jalfsoftware.jalf.entities.AbstractEntity;
 import com.jalfsoftware.jalf.entities.Player;
 import com.jalfsoftware.jalf.helper.Map;
+import com.jalfsoftware.jalf.services.ConsoleManager;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 /**
  * Screen zur Darstellung des Spiels
  */
-public class GameScreen extends AbstractScreen implements Player.EndOfMapReachedListener {
+public class GameScreen extends AbstractScreen implements Player.EndOfMapReachedListener, ConsoleManager.CommandableScreen {
     public static final float UNITSCALE            = 0.75f; // Skalierungskonstante für die Darstellung von Maps und Entitäten
     public static final float GRAVITATION_CONSTANT = 0.2f;
 
@@ -139,5 +141,15 @@ public class GameScreen extends AbstractScreen implements Player.EndOfMapReached
     public void addPoolableEntityToRenderLoop(AbstractEntity entity) {
         poolableEntityList.add(entity);
         //System.out.println(poolableEntityList.size() + "Poolable Entities will be rendered...");
+    }
+
+    @Override
+    public void addScreenConsoleCommand(ConsoleManager consoleManager) {
+        consoleManager.addCommand(new ConsoleManager.ConsoleCommand("respawn", new ConsoleManager.CommandExecutor() {
+            @Override
+            public void OnCommandFired(HashMap<String, String> parValuePairs) {
+                player.respawn();
+            }
+        }));
     }
 }

--- a/core/src/com/jalfsoftware/jalf/services/ConsoleManager.java
+++ b/core/src/com/jalfsoftware/jalf/services/ConsoleManager.java
@@ -1,0 +1,69 @@
+package com.jalfsoftware.jalf.services;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Created by Flaiker on 29.11.2014.
+ */
+public class ConsoleManager {
+    private List<ConsoleCommand> commandList = new ArrayList<>();
+
+    public void addCommand(ConsoleCommand command) {
+        commandList.add(command);
+    }
+
+    public void clearCommands() {
+        commandList.clear();
+    }
+
+    public void submitConsoleString(String commandString) {
+        ConsoleCommand foundCommand = null;
+        String normalizedString = commandString.trim().replaceAll("\\s+", " ");
+        String commandName = normalizedString.split(" ")[0];
+
+        for (ConsoleCommand command : commandList) {
+            if (command.commandName.equals(commandName)) foundCommand = command;
+        }
+
+        if (foundCommand == null) return;
+
+        HashMap<String, String> parValuePairs = new HashMap<>();
+        if (commandString.trim().length() - commandName.length() + 1 > 2) {
+            String parString = normalizedString.substring(commandName.length() + 1);
+            String[] parStrings = parString.split(" ");
+            for (String pair : parStrings) {
+                String[] parAndValue = pair.split(":");
+                if (parAndValue.length == 2) {
+                    String par = parAndValue[0];
+                    String val = parAndValue[1];
+                    parValuePairs.put(par, val);
+                } else parValuePairs.put(pair, "");
+            }
+        }
+        foundCommand.executeMethod.OnCommandFired(parValuePairs);
+    }
+
+    public static class ConsoleCommand {
+        private String          commandName;
+        private CommandExecutor executeMethod;
+
+        public ConsoleCommand(String command, CommandExecutor executeMethod) {
+            this.commandName = command;
+            this.executeMethod = executeMethod;
+        }
+
+        public String getCommandName() {
+            return commandName;
+        }
+    }
+
+    public interface CommandExecutor {
+        public void OnCommandFired(HashMap<String, String> parValuePairs);
+    }
+
+    public interface CommandableScreen {
+        public void addScreenConsoleCommand(ConsoleManager consoleManager);
+    }
+}


### PR DESCRIPTION
Per Shift+ESC lässt sich nun in allen Screens eine Konsole öffnen/schließen. Befehle werden screenübergreifend in Jalf.java (initializeConsoleCommands()) oder screenspezifisch in addScreenConsoleCommand() über das CommandableScreen-Interface registriert.

Aktuell implementierte Befehle:
- fullscreen true
- fullscreen false
- exit
- respawn (im Gamescreen)
